### PR TITLE
Add dedicated MATLAB & Simulink capabilities page

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,6 +16,7 @@
     <a href="/" class="flex items-center gap-3"><img src="/assets/logo.svg" class="h-8 w-auto" alt="ControlStackAI"/></a>
     <nav class="hidden md:flex items-center gap-6 text-sm text-slate-300">
       <a href="/services.html" class="hover:text-white">Services</a>
+      <a href="/matlab-simulink.html" class="hover:text-white">MATLAB &amp; Simulink</a>
       <a href="/about.html" class="hover:text-white">About</a>
       <a href="/contact.html" class="hover:text-white">Contact</a>
     </nav>

--- a/assets/matlab-automation-loop.svg
+++ b/assets/matlab-automation-loop.svg
@@ -1,0 +1,11 @@
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="360" rx="32" fill="#0B1120"/>
+  <circle cx="320" cy="180" r="130" stroke="#F97316" stroke-width="8" stroke-dasharray="20 16"/>
+  <circle cx="320" cy="180" r="96" fill="#1E3A8A"/>
+  <path d="M320 96L350 148H290L320 96Z" fill="#38BDF8"/>
+  <path d="M320 264L290 212H350L320 264Z" fill="#38BDF8"/>
+  <rect x="160" y="140" width="80" height="80" rx="16" fill="#1E293B" stroke="#22D3EE" stroke-width="3"/>
+  <rect x="400" y="140" width="80" height="80" rx="16" fill="#1E293B" stroke="#22D3EE" stroke-width="3"/>
+  <path d="M240 180H400" stroke="#F8FAFC" stroke-width="5" stroke-linecap="round" stroke-dasharray="18 18"/>
+  <text x="320" y="190" text-anchor="middle" fill="#F8FAFC" font-family="'Inter', 'Segoe UI', sans-serif" font-size="22" font-weight="600">Automation Loop</text>
+</svg>

--- a/assets/matlab-simulink-integration.svg
+++ b/assets/matlab-simulink-integration.svg
@@ -1,0 +1,9 @@
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="360" rx="32" fill="#0F172A"/>
+  <rect x="60" y="60" width="520" height="240" rx="24" fill="#1E293B" stroke="#38BDF8" stroke-width="3" stroke-dasharray="14 14"/>
+  <path d="M120 220C160 160 220 140 260 200C300 260 360 250 400 200C440 150 500 150 540 200" stroke="#F97316" stroke-width="6" stroke-linecap="round"/>
+  <path d="M180 140L160 100L220 110L240 150L210 170L180 140Z" fill="#FACC15" opacity="0.8"/>
+  <circle cx="460" cy="140" r="34" fill="#22D3EE" opacity="0.6"/>
+  <rect x="420" y="230" width="120" height="46" rx="14" fill="#22D3EE" fill-opacity="0.2" stroke="#22D3EE" stroke-width="2"/>
+  <text x="120" y="280" fill="#E2E8F0" font-family="'Inter', 'Segoe UI', sans-serif" font-size="24" font-weight="600">Model integration surface</text>
+</svg>

--- a/assets/simulink-ci-dashboard.svg
+++ b/assets/simulink-ci-dashboard.svg
@@ -1,0 +1,13 @@
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="360" rx="32" fill="#020617"/>
+  <rect x="80" y="60" width="480" height="240" rx="24" fill="#111827" stroke="#22D3EE" stroke-width="3"/>
+  <rect x="120" y="100" width="180" height="160" rx="16" fill="#1E293B"/>
+  <rect x="340" y="100" width="180" height="160" rx="16" fill="#1E293B"/>
+  <path d="M140 220L180 160L210 190L240 140L280 220" stroke="#38BDF8" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="360" y="128" width="60" height="24" rx="8" fill="#22C55E"/>
+  <rect x="430" y="128" width="60" height="24" rx="8" fill="#F97316"/>
+  <rect x="360" y="168" width="130" height="16" rx="8" fill="#0EA5E9"/>
+  <rect x="360" y="196" width="90" height="16" rx="8" fill="#6366F1"/>
+  <rect x="360" y="224" width="110" height="16" rx="8" fill="#EAB308"/>
+  <text x="320" y="300" text-anchor="middle" fill="#E2E8F0" font-family="'Inter', 'Segoe UI', sans-serif" font-size="22" font-weight="600">Continuous Integration Dashboard</text>
+</svg>

--- a/contact.html
+++ b/contact.html
@@ -16,6 +16,7 @@
     <a href="/" class="flex items-center gap-3"><img src="/assets/logo.svg" class="h-8 w-auto" alt="ControlStackAI"/></a>
     <nav class="hidden md:flex items-center gap-6 text-sm text-slate-300">
       <a href="/services.html" class="hover:text-white">Services</a>
+      <a href="/matlab-simulink.html" class="hover:text-white">MATLAB &amp; Simulink</a>
       <a href="/about.html" class="hover:text-white">About</a>
       <a href="/contact.html" class="hover:text-white">Contact</a>
     </nav>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <a href="/" class="flex items-center gap-3"><img src="/assets/logo.svg" class="h-8 w-auto" alt="ControlStackAI"/></a>
     <nav class="hidden md:flex items-center gap-6 text-sm text-slate-300">
       <a href="/services.html" class="hover:text-white">Services</a>
+      <a href="/matlab-simulink.html" class="hover:text-white">MATLAB &amp; Simulink</a>
       <a href="#work" class="hover:text-white">Work</a>
       <a href="/about.html" class="hover:text-white">About</a>
       <a href="/contact.html" class="hover:text-white">Contact</a>

--- a/matlab-simulink.html
+++ b/matlab-simulink.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>MATLAB & Simulink Engineering Productivity — ControlStackAI</title><meta name="description" content="Custom MATLAB and Simulink tooling, automation, and workflows that accelerate engineering teams."/>
+<meta property="og:title" content="MATLAB & Simulink Engineering Productivity — ControlStackAI"/><meta property="og:description" content="Custom MATLAB and Simulink tooling, automation, and workflows that accelerate engineering teams."/>
+<meta property="og:image" content="/assets/matlab-simulink-integration.svg"/>
+<link rel="icon" href="/assets/logo.svg" type="image/svg+xml"/>
+<script src="https://cdn.tailwindcss.com"></script>
+<script src="/styles/tailwind-cdn.js"></script>
+<style>.glass{background:rgba(255,255,255,0.05);backdrop-filter:blur(6px);}</style>
+</head><body class="bg-ink text-slate-100 antialiased selection:bg-accent/30 selection:text-ink">
+<header class="sticky top-0 z-50 border-b border-white/5 bg-ink/80 backdrop-blur">
+  <div class="mx-auto max-w-7xl px-4 py-3 flex items-center justify-between">
+    <a href="/" class="flex items-center gap-3"><img src="/assets/logo.svg" class="h-8 w-auto" alt="ControlStackAI"/></a>
+    <nav class="hidden md:flex items-center gap-6 text-sm text-slate-300">
+      <a href="/services.html" class="hover:text-white">Services</a>
+      <a href="/matlab-simulink.html" class="hover:text-white text-white">MATLAB &amp; Simulink</a>
+      <a href="/about.html" class="hover:text-white">About</a>
+      <a href="/contact.html" class="hover:text-white">Contact</a>
+    </nav>
+    <a href="/contact.html" class="inline-flex items-center rounded-xl bg-accent/90 px-4 py-2 text-ink font-semibold hover:bg-accent">Book a consult</a>
+  </div>
+</header>
+<main>
+  <section class="relative overflow-hidden border-b border-white/5">
+    <img src="/assets/matlab-simulink-integration.svg" alt="MATLAB and Simulink integration illustration" class="absolute inset-0 h-full w-full object-cover opacity-20"/>
+    <div class="relative mx-auto max-w-5xl px-4 py-24">
+      <span class="text-sm font-semibold uppercase tracking-[0.3em] text-accent/80">MATLAB &amp; SIMULINK</span>
+      <h1 class="mt-4 text-4xl md:text-5xl font-extrabold text-white">Engineering tools that keep your teams shipping</h1>
+      <p class="mt-6 max-w-3xl text-lg text-slate-300">We build MATLAB apps, Simulink automation, and CI-ready workflows that remove friction from modeling, verification, and deployment. Our tooling empowers your engineering teams to move faster while staying compliant with safety and certification requirements.</p>
+      <div class="mt-8 flex flex-wrap gap-3 text-sm font-semibold text-ink">
+        <div class="rounded-full bg-white/90 px-4 py-2 text-ink/90">Custom apps &amp; toolboxes</div>
+        <div class="rounded-full bg-white/90 px-4 py-2 text-ink/90">Model-based design automation</div>
+        <div class="rounded-full bg-white/90 px-4 py-2 text-ink/90">Continuous verification pipelines</div>
+      </div>
+      <div class="mt-10 flex flex-wrap gap-3">
+        <a href="/contact.html" class="rounded-xl bg-accent/90 px-5 py-3 text-ink font-semibold hover:bg-accent">Discuss a workflow</a>
+        <a href="/services.html" class="rounded-xl border border-white/10 px-5 py-3 text-white hover:bg-white/5">See all services</a>
+      </div>
+    </div>
+  </section>
+  <section class="mx-auto max-w-6xl px-4 py-16">
+    <div class="grid gap-10 lg:grid-cols-[1.1fr,0.9fr] lg:items-center">
+      <div class="space-y-6">
+        <h2 class="text-3xl font-bold text-white">Purpose-built tooling for your modeling stack</h2>
+        <p class="text-slate-300">We partner with controls, autonomy, and test engineers to design MATLAB applications and Simulink libraries that feel native to your environment. From reusable blocksets to data-driven dashboards, we deliver interfaces that reflect how your teams already work.</p>
+        <ul class="list-disc space-y-2 pl-5 text-slate-300">
+          <li>Interactive GUIs for parameter studies, flight ops, and certification packages</li>
+          <li>Reusable block libraries and scripts aligned to your architecture standards</li>
+          <li>Integrated documentation and traceability with Requirements Toolbox</li>
+        </ul>
+      </div>
+      <div class="glass rounded-3xl border border-white/5 p-6">
+        <img src="/assets/matlab-automation-loop.svg" alt="Automation loop graphic" class="w-full rounded-2xl border border-white/5"/>
+        <p class="mt-4 text-sm text-slate-300">Tooling engagements typically ship in <span class="font-semibold text-white">6–10 weeks</span>, with ongoing support for capability growth.</p>
+      </div>
+    </div>
+  </section>
+  <section class="mx-auto max-w-6xl px-4 pb-16">
+    <div class="glass rounded-3xl border border-white/5 p-8 md:p-12">
+      <div class="grid gap-10 lg:grid-cols-[0.9fr,1.1fr] lg:items-center">
+        <div class="space-y-5">
+          <h2 class="text-3xl font-bold text-white">Automation that keeps engineers in flow</h2>
+          <p class="text-slate-300">We design MATLAB and Simulink workflows that offload repetitive tasks and surface feedback where decisions happen. Scriptable pipelines, Simulink Test harnesses, and auto-generated reports ensure your teams stay focused on solving engineering problems—not chasing builds.</p>
+          <div class="grid gap-4 md:grid-cols-2">
+            <div class="rounded-2xl border border-white/5 p-4">
+              <h3 class="text-lg font-semibold text-white">Continuous validation</h3>
+              <p class="mt-2 text-sm text-slate-300">CI-ready automation for Simulink Test, SIL/HIL, and coverage metrics delivered to your dashboards.</p>
+            </div>
+            <div class="rounded-2xl border border-white/5 p-4">
+              <h3 class="text-lg font-semibold text-white">Release confidence</h3>
+              <p class="mt-2 text-sm text-slate-300">Model Advisor rules, coding standards, and traceability enforced automatically before every release.</p>
+            </div>
+          </div>
+        </div>
+        <img src="/assets/simulink-ci-dashboard.svg" alt="Simulink CI dashboard illustration" class="w-full rounded-2xl border border-white/5"/>
+      </div>
+    </div>
+  </section>
+  <section class="mx-auto max-w-6xl px-4 pb-16">
+    <div class="grid gap-6 md:grid-cols-3">
+      <div class="glass rounded-2xl border border-white/5 p-6">
+        <div class="text-sm uppercase tracking-wide text-accent/90">Team velocity</div>
+        <h3 class="mt-2 text-xl font-semibold text-white">Accelerate delivery</h3>
+        <p class="mt-3 text-sm text-slate-300">Automate regression runs, result triage, and packaging so engineers iterate without waiting on tooling.</p>
+      </div>
+      <div class="glass rounded-2xl border border-white/5 p-6">
+        <div class="text-sm uppercase tracking-wide text-accent/90">Quality</div>
+        <h3 class="mt-2 text-xl font-semibold text-white">Raise confidence</h3>
+        <p class="mt-3 text-sm text-slate-300">Embed verification, standards compliance, and documentation hooks throughout your modeling workflow.</p>
+      </div>
+      <div class="glass rounded-2xl border border-white/5 p-6">
+        <div class="text-sm uppercase tracking-wide text-accent/90">Collaboration</div>
+        <h3 class="mt-2 text-xl font-semibold text-white">Keep everyone aligned</h3>
+        <p class="mt-3 text-sm text-slate-300">Connect MATLAB/Simulink with data lakes, Git, and planning tools to keep cross-functional teams synced.</p>
+      </div>
+    </div>
+  </section>
+  <section class="mx-auto max-w-5xl px-4 pb-24">
+    <div class="glass rounded-3xl border border-white/5 p-10 text-center">
+      <h2 class="text-3xl font-bold text-white">Ready to modernize your MATLAB &amp; Simulink workflows?</h2>
+      <p class="mt-4 text-slate-300">Let’s co-design automation and tooling that give your engineers more time for breakthroughs. We engage with aerospace, robotics, and advanced manufacturing teams worldwide.</p>
+      <a href="/contact.html" class="mt-8 inline-flex items-center rounded-xl bg-accent/90 px-6 py-3 text-ink font-semibold hover:bg-accent">Start the conversation</a>
+    </div>
+  </section>
+</main>
+<footer class="border-t border-white/5">
+  <div class="mx-auto max-w-7xl px-4 py-10 grid gap-6 md:grid-cols-3 text-sm text-slate-400">
+    <div><div class="text-white font-semibold">ControlStackAI</div><div class="text-slate-400">Agentic AI workflows for engineering teams</div></div>
+    <div><div class="font-semibold text-slate-300 mb-2">Contact</div><div><a href="mailto:matthew@mangano-consulting.com" class="hover:text-white">matthew@mangano-consulting.com</a></div></div>
+    <div><div class="font-semibold text-slate-300 mb-2">Legal</div><a class="block hover:text-white" href="/privacy.html">Privacy</a><a class="block hover:text-white" href="/terms.html">Terms</a></div>
+  </div>
+  <div class="mx-auto max-w-7xl px-4 pb-8 text-xs text-slate-500">© 2025-09-25 ControlStackAI. All rights reserved.</div>
+</footer></body></html>

--- a/services.html
+++ b/services.html
@@ -16,6 +16,7 @@
     <a href="/" class="flex items-center gap-3"><img src="/assets/logo.svg" class="h-8 w-auto" alt="ControlStackAI"/></a>
     <nav class="hidden md:flex items-center gap-6 text-sm text-slate-300">
       <a href="/services.html" class="hover:text-white">Services</a>
+      <a href="/matlab-simulink.html" class="hover:text-white">MATLAB &amp; Simulink</a>
       <a href="/about.html" class="hover:text-white">About</a>
       <a href="/contact.html" class="hover:text-white">Contact</a>
     </nav>


### PR DESCRIPTION
## Summary
- add a new MATLAB & Simulink capabilities page with detailed tooling, automation, and productivity content
- create bespoke hero and workflow illustrations to support the new page
- surface the new page in the primary navigation across the site

## Testing
- python -m http.server 8000 (manual)


------
https://chatgpt.com/codex/tasks/task_e_68d5f10f27cc832f86ef41074d68aebe