### PR TITLE
Refresh homepage capabilities cards styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,36 +44,39 @@
 </section>
 <section class="mx-auto max-w-7xl px-4 py-16">
   <div class="grid gap-8 md:grid-cols-3">
-    <div class="glass rounded-2xl border border-white/5 p-8">
-      <div class="text-sm uppercase tracking-wide text-accent/90">Tier 01</div>
+    <article class="relative flex flex-col overflow-hidden rounded-2xl border border-white/10 bg-slate-900/40 p-8 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.9)] transition duration-300 hover:border-accent/70 hover:shadow-[0_25px_55px_-30px_rgba(59,130,246,0.55)]">
+      <div class="absolute inset-x-8 top-0 h-px bg-gradient-to-r from-accent/70 via-white/60 to-accent/40 opacity-75"></div>
       <h2 class="mt-2 text-2xl font-semibold text-white">Agentic AI Systems</h2>
-      <p class="mt-4 text-slate-400">Designing orchestration frameworks with reasoning loops, policy guardrails, and evaluation sandboxes that let autonomous agents work safely alongside your teams.</p>
-      <dl class="mt-6 space-y-3 text-sm text-slate-300">
-        <div class="flex items-start gap-3"><dt class="font-semibold text-white">Orchestration</dt><dd>Multi-agent planning, delegation, and grounding for complex delivery pipelines.</dd></div>
-        <div class="flex items-start gap-3"><dt class="font-semibold text-white">Control</dt><dd>Safety switches, role-based guardrails, and audit trails with automatic reporting.</dd></div>
-        <div class="flex items-start gap-3"><dt class="font-semibold text-white">Impact</dt><dd><span class="font-semibold text-accent">45% faster</span> release reviews using autonomous PR copilots.</dd></div>
-      </dl>
-    </div>
-    <div class="glass rounded-2xl border border-white/5 p-8">
-      <div class="text-sm uppercase tracking-wide text-accent/90">Tier 02</div>
+      <p class="mt-4 text-sm text-slate-300">Tool-chaining AI that breaks goals into steps, calls APIs, checks results, and improves with feedback.</p>
+      <ul class="mt-6 space-y-3 text-sm text-slate-200">
+        <li class="flex items-start gap-3"><span class="mt-1 h-2.5 w-2.5 rounded-full bg-accent/90"></span><span>Multi-step planning &amp; tool use</span></li>
+        <li class="flex items-start gap-3"><span class="mt-1 h-2.5 w-2.5 rounded-full bg-accent/60"></span><span>Automation over API workflows</span></li>
+        <li class="flex items-start gap-3"><span class="mt-1 h-2.5 w-2.5 rounded-full bg-accent/40"></span><span>Human-in-the-loop controls</span></li>
+      </ul>
+      <a href="/services.html#agentic" class="mt-auto inline-flex items-center pt-6 text-sm font-semibold text-accent hover:text-accent/80">Learn more →</a>
+    </article>
+    <article class="relative flex flex-col overflow-hidden rounded-2xl border border-white/10 bg-slate-900/40 p-8 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.9)] transition duration-300 hover:border-accent/70 hover:shadow-[0_25px_55px_-30px_rgba(59,130,246,0.55)]">
+      <div class="absolute inset-x-8 top-0 h-px bg-gradient-to-r from-accent/70 via-white/60 to-accent/40 opacity-75"></div>
       <h2 class="mt-2 text-2xl font-semibold text-white">Machine Learning Platforms</h2>
-      <p class="mt-4 text-slate-400">Full-stack ML engineering—from data strategy through CI/CD for models—so insights ship to production reliably and repeatedly.</p>
-      <dl class="mt-6 space-y-3 text-sm text-slate-300">
-        <div class="flex items-start gap-3"><dt class="font-semibold text-white">Pipelines</dt><dd>Feature stores, experiment tracking, and automated validation.</dd></div>
-        <div class="flex items-start gap-3"><dt class="font-semibold text-white">Operations</dt><dd>Model governance, monitoring, and on-call playbooks for ML services.</dd></div>
-        <div class="flex items-start gap-3"><dt class="font-semibold text-white">Impact</dt><dd><span class="font-semibold text-accent">99.8% uptime</span> ML APIs across hybrid infrastructure.</dd></div>
-      </dl>
-    </div>
-    <div class="glass rounded-2xl border border-white/5 p-8">
-      <div class="text-sm uppercase tracking-wide text-accent/90">Tier 03</div>
+      <p class="mt-4 text-sm text-slate-300">From classic models to time-series forecasting and anomaly detection tailored to your data.</p>
+      <ul class="mt-6 space-y-3 text-sm text-slate-200">
+        <li class="flex items-start gap-3"><span class="mt-1 h-2.5 w-2.5 rounded-full bg-accent/90"></span><span>Feature engineering</span></li>
+        <li class="flex items-start gap-3"><span class="mt-1 h-2.5 w-2.5 rounded-full bg-accent/60"></span><span>Evaluation &amp; validation</span></li>
+        <li class="flex items-start gap-3"><span class="mt-1 h-2.5 w-2.5 rounded-full bg-accent/40"></span><span>Productionization</span></li>
+      </ul>
+      <a href="/services.html#ml" class="mt-auto inline-flex items-center pt-6 text-sm font-semibold text-accent hover:text-accent/80">Learn more →</a>
+    </article>
+    <article class="relative flex flex-col overflow-hidden rounded-2xl border border-white/10 bg-slate-900/40 p-8 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.9)] transition duration-300 hover:border-accent/70 hover:shadow-[0_25px_55px_-30px_rgba(59,130,246,0.55)]">
+      <div class="absolute inset-x-8 top-0 h-px bg-gradient-to-r from-accent/70 via-white/60 to-accent/40 opacity-75"></div>
       <h2 class="mt-2 text-2xl font-semibold text-white">Deep Learning Innovation</h2>
-      <p class="mt-4 text-slate-400">Custom neural architectures, fine-tuning, and multimodal systems that unlock new autonomy and perception capabilities.</p>
-      <dl class="mt-6 space-y-3 text-sm text-slate-300">
-        <div class="flex items-start gap-3"><dt class="font-semibold text-white">Architecture</dt><dd>Transformers, diffusion, and graph networks tuned for your domain.</dd></div>
-        <div class="flex items-start gap-3"><dt class="font-semibold text-white">Acceleration</dt><dd>Inference optimization across GPU, TPU, and embedded targets.</dd></div>
-        <div class="flex items-start gap-3"><dt class="font-semibold text-white">Impact</dt><dd><span class="font-semibold text-accent">3× faster</span> perception loops with compressed multimodal models.</dd></div>
-      </dl>
-    </div>
+      <p class="mt-4 text-sm text-slate-300">Vision, sequence models, and embeddings for resilient autonomy and perception pipelines.</p>
+      <ul class="mt-6 space-y-3 text-sm text-slate-200">
+        <li class="flex items-start gap-3"><span class="mt-1 h-2.5 w-2.5 rounded-full bg-accent/90"></span><span>RAG &amp; vector search</span></li>
+        <li class="flex items-start gap-3"><span class="mt-1 h-2.5 w-2.5 rounded-full bg-accent/60"></span><span>Vision &amp; multimodal</span></li>
+        <li class="flex items-start gap-3"><span class="mt-1 h-2.5 w-2.5 rounded-full bg-accent/40"></span><span>Fine-tuning &amp; adapters</span></li>
+      </ul>
+      <a href="/services.html#deep-learning" class="mt-auto inline-flex items-center pt-6 text-sm font-semibold text-accent hover:text-accent/80">Learn more →</a>
+    </article>
   </div>
 </section>
 <section id="work" class="mx-auto max-w-7xl px-4 pb-16">


### PR DESCRIPTION
## Summary
- restyle the homepage capability cards to match the simpler feature highlights look
- replace tier labels with bullet lists and gradient accents for each offering card

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d5f78be948832f8be8271e07a47636