### PR TITLE
Site buildout: platform, integrations, security, manifesto

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>About - ControlStackAI</title>
-  <meta name="description" content="ControlStackAI LLC builds agent infrastructure for regulated engineering teams.">
+  <meta name="description" content="ControlStackAI LLC builds agent infrastructure for regulated engineering teams. Founded by Matthew Mangano, an aerospace controls engineer.">
   <link rel="canonical" href="https://controlstackai.com/about.html">
   <link rel="icon" href="/assets/icon-neural-grid.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
@@ -18,26 +18,48 @@
       <div class="flex items-center gap-5 text-sm text-slate-300"><a href="/manifesto.html" class="hover:text-white">Manifesto</a><a href="/#early-access" class="rounded-md bg-accent px-3 py-2 font-medium text-white hover:bg-accent/90">Early access</a></div>
     </nav>
   </header>
+
   <main class="mx-auto max-w-5xl px-5 py-20">
     <p class="text-sm font-medium uppercase tracking-[.2em] text-accent">About</p>
     <h1 class="mt-4 max-w-4xl text-4xl font-semibold tracking-tight md:text-6xl">Agent infrastructure for engineering teams that cannot treat AI as shadow IT.</h1>
-    <div class="mt-10 grid gap-10 lg:grid-cols-[1fr_22rem]">
+
+    <div class="mt-12 grid gap-10 lg:grid-cols-[1fr_22rem]">
       <div class="space-y-6 leading-8 text-slate-300">
         <p>ControlStackAI LLC is a Wyoming company building an agent platform for engineering teams in regulated industries. The platform is designed for work that needs tool access, reviewability, long-running execution, and deployment inside customer-controlled infrastructure.</p>
         <p>The product direction comes from a simple premise: engineering teams will not get real leverage from isolated chat tools. They need agent teams that can operate existing toolchains, create durable artifacts, and leave an audit trail.</p>
-        <p>ControlStackAI focuses on the platform layer: agent runtime, engineering-tool integrations, provider-agnostic inference, governance, and deployment models for on-prem, VPC, and air-gapped environments.</p>
+        <p>ControlStackAI focuses on the platform layer &mdash; agent runtime, engineering-tool integrations, provider-agnostic inference, governance, and deployment models for on-prem, VPC, and air-gapped environments. We do not compete with the modeling, requirements, or test tools your team already runs. We make agents able to use them.</p>
+
+        <h2 class="pt-6 text-xl font-semibold text-white">Founder</h2>
+        <p>Matthew Mangano is an aerospace controls and flight dynamics engineer. He has spent the last decade close to the work of shipping safety-critical engineering artifacts under schedule pressure, and built commercial engineering tooling used by real aerospace teams to design and validate aircraft.</p>
+        <p>That background shaped what ControlStackAI is and is not. It is not a re-skinned consumer AI tool. It is a platform built around the constraints engineering teams actually operate under: reviewable artifacts, scoped agent actions, regulated deployment, and integrations with the toolchain that already runs the work.</p>
+
+        <h2 class="pt-6 text-xl font-semibold text-white">Where we are</h2>
+        <p>The company is in design-partner mode. The platform is being built alongside engineering teams that have real workflows to automate and real infrastructure constraints to respect. Public launch happens when the platform is ready to be trusted by the kind of teams we are building it for.</p>
+
+        <h2 class="pt-6 text-xl font-semibold text-white">What we are not</h2>
+        <p>We are not a flight dynamics tool, a controls design product, or a competitor to existing engineering software. We are not building a token exchange, a model marketplace, or another chat front-end. ControlStackAI is purposely positioned as an agent platform, on top of and alongside the engineering tools you already use.</p>
       </div>
-      <aside class="panel border border-white/10 p-6">
-        <h2 class="text-lg font-semibold">Company</h2>
-        <dl class="mt-5 space-y-4 text-sm text-slate-300">
-          <div><dt class="text-slate-500">Legal name</dt><dd>ControlStackAI LLC</dd></div>
-          <div><dt class="text-slate-500">Jurisdiction</dt><dd>Wyoming</dd></div>
-          <div><dt class="text-slate-500">Filing</dt><dd>2026-001983812</dd></div>
-          <div><dt class="text-slate-500">Contact</dt><dd><a class="text-accent hover:text-white" href="mailto:hello@controlstackai.com">hello@controlstackai.com</a></dd></div>
-        </dl>
+
+      <aside class="space-y-6">
+        <div class="panel border border-white/10 p-6">
+          <h2 class="text-lg font-semibold">Company</h2>
+          <dl class="mt-5 space-y-4 text-sm text-slate-300">
+            <div><dt class="text-slate-500">Legal name</dt><dd>ControlStackAI LLC</dd></div>
+            <div><dt class="text-slate-500">Jurisdiction</dt><dd>Wyoming, USA</dd></div>
+            <div><dt class="text-slate-500">Filing</dt><dd>2026-001983812</dd></div>
+            <div><dt class="text-slate-500">Founded</dt><dd>2026</dd></div>
+            <div><dt class="text-slate-500">Contact</dt><dd><a class="text-accent hover:text-white" href="mailto:hello@controlstackai.com">hello@controlstackai.com</a></dd></div>
+          </dl>
+        </div>
+        <div class="panel border border-white/10 p-6">
+          <h2 class="text-lg font-semibold">Working with us</h2>
+          <p class="mt-3 text-sm leading-6 text-slate-400">Design-partner conversations start with MNDA and a scoped pilot. We do not put serious teams on a marketing waitlist.</p>
+          <a href="/#early-access" class="mt-4 inline-flex rounded-md bg-accent px-4 py-2 text-sm font-semibold text-white hover:bg-accent/90">Request early access</a>
+        </div>
       </aside>
     </div>
   </main>
-  <footer class="border-t border-white/10"><div class="mx-auto flex max-w-7xl flex-col gap-4 px-5 py-8 text-sm text-slate-400 md:flex-row md:items-center md:justify-between"><p>&copy; 2026 ControlStackAI LLC · Wyoming · <a class="hover:text-white" href="mailto:hello@controlstackai.com">hello@controlstackai.com</a></p><div class="flex gap-4"><a href="/privacy.html" class="hover:text-white">Privacy</a><a href="/terms.html" class="hover:text-white">Terms</a></div></div></footer>
+
+  <footer class="border-t border-white/10"><div class="mx-auto flex max-w-7xl flex-col gap-4 px-5 py-8 text-sm text-slate-400 md:flex-row md:items-center md:justify-between"><p>&copy; 2026 ControlStackAI LLC &middot; Wyoming &middot; <a class="hover:text-white" href="mailto:hello@controlstackai.com">hello@controlstackai.com</a></p><div class="flex gap-4"><a href="/privacy.html" class="hover:text-white">Privacy</a><a href="/terms.html" class="hover:text-white">Terms</a></div></div></footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,10 +4,13 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ControlStackAI - The agent platform for engineering teams</title>
-  <meta name="description" content="AI agents that ship real engineering work - controls design, Simulink models, requirements, and test plans - running on your infrastructure.">
+  <meta name="description" content="ControlStackAI is the agent platform for regulated engineering teams. Long-running AI agents that operate MATLAB, Simulink, requirements, and test tooling on your infrastructure.">
   <meta property="og:title" content="ControlStackAI - The agent platform for engineering teams">
   <meta property="og:description" content="AI agents that ship real engineering work on your infrastructure.">
   <meta property="og:image" content="/assets/icon-neural-grid.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://controlstackai.com/">
+  <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://controlstackai.com/">
   <link rel="icon" href="/assets/icon-neural-grid.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
@@ -17,6 +20,8 @@
     body{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
     .line{background:linear-gradient(90deg,rgba(0,102,255,.05),rgba(0,102,255,.9),rgba(255,255,255,.55),rgba(0,102,255,.05))}
     .panel{background:rgba(255,255,255,.035)}
+    .grid-bg{background-image:linear-gradient(rgba(255,255,255,.04) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.04) 1px,transparent 1px);background-size:48px 48px}
+    .num{font-variant-numeric:tabular-nums}
   </style>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"ControlStackAI LLC","url":"https://controlstackai.com","logo":"https://controlstackai.com/assets/icon-neural-grid.svg","email":"hello@controlstackai.com","founder":{"@type":"Person","name":"Matthew Mangano"},"address":{"@type":"PostalAddress","addressRegion":"WY","addressCountry":"US"}}</script>
 </head>
@@ -27,23 +32,31 @@
         <img src="/assets/icon-neural-grid.svg" class="h-8 w-8 rounded-sm" alt="">
         <span class="text-sm font-semibold tracking-tight text-white">ControlStackAI</span>
       </a>
-      <div class="flex items-center gap-5 text-sm text-slate-300">
+      <div class="hidden items-center gap-6 text-sm text-slate-300 md:flex">
+        <a href="#platform" class="hover:text-white">Platform</a>
+        <a href="#integrations" class="hover:text-white">Integrations</a>
+        <a href="#security" class="hover:text-white">Security</a>
         <a href="/manifesto.html" class="hover:text-white">Manifesto</a>
-        <a href="#early-access" class="rounded-md bg-accent px-3 py-2 font-medium text-white hover:bg-accent/90">Early access</a>
+        <a href="/about.html" class="hover:text-white">About</a>
       </div>
+      <a href="#early-access" class="rounded-md bg-accent px-3 py-2 text-sm font-medium text-white hover:bg-accent/90">Early access</a>
     </nav>
   </header>
 
   <main>
-    <section class="mx-auto max-w-7xl px-5 pb-20 pt-16 md:pb-28 md:pt-24">
-      <div class="line mb-12 h-px w-full"></div>
-      <img src="/assets/wordmark-mono.svg" class="h-auto w-full max-w-3xl invert" alt="ControlStackAI">
-      <div class="mt-12 max-w-5xl">
-        <p class="text-xl font-medium text-accent md:text-2xl">The agent platform for engineering teams.</p>
-        <h1 class="mt-5 max-w-4xl text-4xl font-semibold tracking-tight text-white md:text-6xl">AI agents that ship real engineering work, running on your infrastructure.</h1>
-        <p class="mt-6 max-w-3xl text-lg leading-8 text-slate-300">ControlStackAI gives regulated engineering teams a platform for long-running agent work: controls design, Simulink models, requirements, test plans, and reviewable technical artifacts. Agents use the tools your teams already trust.</p>
-        <div class="mt-9">
-          <a href="#early-access" class="inline-flex rounded-md bg-accent px-5 py-3 text-sm font-semibold text-white hover:bg-accent/90">Request early access</a>
+    <section class="relative overflow-hidden">
+      <div class="grid-bg absolute inset-0 opacity-60"></div>
+      <div class="relative mx-auto max-w-7xl px-5 pb-20 pt-16 md:pb-28 md:pt-24">
+        <div class="line mb-12 h-px w-full"></div>
+        <img src="/assets/wordmark-mono.svg" class="h-auto w-full max-w-3xl invert" alt="ControlStackAI">
+        <div class="mt-12 max-w-5xl">
+          <p class="text-xl font-medium text-accent md:text-2xl">The agent platform for engineering teams.</p>
+          <h1 class="mt-5 max-w-4xl text-4xl font-semibold tracking-tight text-white md:text-6xl">AI agents that ship real engineering work, running on your infrastructure.</h1>
+          <p class="mt-6 max-w-3xl text-lg leading-8 text-slate-300">ControlStackAI gives regulated engineering teams a platform for long-running agent work: controls design, Simulink models, requirements, test plans, and reviewable technical artifacts. Agents use the tools your teams already trust.</p>
+          <div class="mt-9 flex flex-wrap gap-3">
+            <a href="#early-access" class="inline-flex rounded-md bg-accent px-5 py-3 text-sm font-semibold text-white hover:bg-accent/90">Request early access</a>
+            <a href="#platform" class="inline-flex rounded-md border border-white/15 px-5 py-3 text-sm font-semibold text-white hover:border-white/30">See the platform</a>
+          </div>
         </div>
       </div>
     </section>
@@ -68,43 +81,127 @@
       </div>
     </section>
 
-    <section class="mx-auto max-w-7xl px-5 py-20">
+    <section id="platform" class="mx-auto max-w-7xl px-5 py-24">
       <div class="max-w-3xl">
-        <p class="text-sm font-medium uppercase tracking-[.2em] text-accent">Who it is for</p>
-        <h2 class="mt-4 text-3xl font-semibold tracking-tight text-white md:text-4xl">Controls, avionics, industrial automation, and regulated engineering teams.</h2>
-        <p class="mt-5 leading-8 text-slate-300">ControlStackAI is built for organizations that see the leverage in agentic AI but cannot send customer designs, controlled data, or proprietary engineering context through unmanaged public tools.</p>
+        <p class="text-sm font-medium uppercase tracking-[.2em] text-accent">Platform</p>
+        <h2 class="mt-4 text-3xl font-semibold tracking-tight text-white md:text-5xl">A context layer for engineering teams, not another chat tool.</h2>
+        <p class="mt-5 leading-8 text-slate-300">ControlStackAI is built around four primitives. Each one is designed for engineering work that takes hours or days, touches regulated data, and needs to leave an audit trail behind.</p>
+      </div>
+      <div class="mt-14 grid gap-px overflow-hidden rounded-lg border border-white/10 md:grid-cols-2">
+        <article class="panel p-8">
+          <p class="num text-sm font-semibold text-accent">01 &mdash; Runtime</p>
+          <h3 class="mt-3 text-xl font-semibold text-white">Long-running agent execution</h3>
+          <p class="mt-4 leading-7 text-slate-300">Stateful agents with planning, replanning, and human review checkpoints. Built for tasks that run overnight, not five-second chat replies.</p>
+        </article>
+        <article class="panel p-8">
+          <p class="num text-sm font-semibold text-accent">02 &mdash; Context</p>
+          <h3 class="mt-3 text-xl font-semibold text-white">Engineering context layer</h3>
+          <p class="mt-4 leading-7 text-slate-300">Models, requirements, test artifacts, controlled documents, and prior decisions become first-class context. Agents reason over what your team has actually built.</p>
+        </article>
+        <article class="panel p-8">
+          <p class="num text-sm font-semibold text-accent">03 &mdash; Tools</p>
+          <h3 class="mt-3 text-xl font-semibold text-white">Operate the tools engineers use</h3>
+          <p class="mt-4 leading-7 text-slate-300">MATLAB, Simulink, Stateflow, CAD, requirements managers, test harnesses, and CI driven through the Model Context Protocol and signed tool adapters.</p>
+        </article>
+        <article class="panel p-8">
+          <p class="num text-sm font-semibold text-accent">04 &mdash; Governance</p>
+          <h3 class="mt-3 text-xl font-semibold text-white">Reviewable, auditable, scoped</h3>
+          <p class="mt-4 leading-7 text-slate-300">Per-agent scopes, tool allowlists, signed actions, full execution traces, and reviewer sign-off before outputs land in your engineering systems.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="integrations" class="border-y border-white/10 bg-white/[.025]">
+      <div class="mx-auto max-w-7xl px-5 py-24">
+        <div class="grid gap-12 lg:grid-cols-[1fr_1.2fr]">
+          <div>
+            <p class="text-sm font-medium uppercase tracking-[.2em] text-accent">Integrations</p>
+            <h2 class="mt-4 text-3xl font-semibold tracking-tight text-white md:text-4xl">Agents that operate the toolchain you already shipped on.</h2>
+            <p class="mt-5 leading-8 text-slate-300">Engineering leverage comes from automating the actual work, not from a parallel AI workflow that nobody trusts. ControlStackAI agents drive your existing tools through audited adapters.</p>
+            <p class="mt-4 leading-8 text-slate-400">Connectors ship for the most common engineering surfaces. New ones are added per design partner.</p>
+          </div>
+          <div class="grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-white/10 sm:grid-cols-3">
+            <div class="panel p-5"><p class="text-xs font-semibold uppercase tracking-wider text-accent">Modeling</p><p class="mt-2 text-sm font-medium text-white">MATLAB</p><p class="text-sm text-slate-400">Simulink, Stateflow</p></div>
+            <div class="panel p-5"><p class="text-xs font-semibold uppercase tracking-wider text-accent">Requirements</p><p class="mt-2 text-sm font-medium text-white">DOORS, Polarion</p><p class="text-sm text-slate-400">Jama, Requirements Toolbox</p></div>
+            <div class="panel p-5"><p class="text-xs font-semibold uppercase tracking-wider text-accent">Test</p><p class="mt-2 text-sm font-medium text-white">Simulink Test</p><p class="text-sm text-slate-400">pytest, GoogleTest</p></div>
+            <div class="panel p-5"><p class="text-xs font-semibold uppercase tracking-wider text-accent">Version control</p><p class="mt-2 text-sm font-medium text-white">Git</p><p class="text-sm text-slate-400">GitHub, GitLab, Azure</p></div>
+            <div class="panel p-5"><p class="text-xs font-semibold uppercase tracking-wider text-accent">Compute</p><p class="mt-2 text-sm font-medium text-white">SLURM, K8s</p><p class="text-sm text-slate-400">On-prem GPUs</p></div>
+            <div class="panel p-5"><p class="text-xs font-semibold uppercase tracking-wider text-accent">Inference</p><p class="mt-2 text-sm font-medium text-white">Provider-agnostic</p><p class="text-sm text-slate-400">Frontier + private</p></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="security" class="mx-auto max-w-7xl px-5 py-24">
+      <div class="grid gap-12 lg:grid-cols-[1.1fr_1fr]">
+        <div>
+          <p class="text-sm font-medium uppercase tracking-[.2em] text-accent">Security &amp; infrastructure</p>
+          <h2 class="mt-4 text-3xl font-semibold tracking-tight text-white md:text-4xl">Built for teams that cannot send their designs through public chat tools.</h2>
+          <p class="mt-5 leading-8 text-slate-300">ControlStackAI is designed for engineering organizations under ITAR, EAR, CUI, customer NDAs, and internal IP boundaries. The platform makes those constraints first-class, not workarounds.</p>
+        </div>
+        <ul class="space-y-5">
+          <li class="panel border border-white/10 p-5"><p class="text-sm font-semibold text-white">On-prem and VPC deployment</p><p class="mt-1 text-sm text-slate-400">Run the platform inside your own cloud account or data center. Customer-controlled keys, customer-controlled inference endpoints.</p></li>
+          <li class="panel border border-white/10 p-5"><p class="text-sm font-semibold text-white">Air-gapped and offline-capable paths</p><p class="mt-1 text-sm text-slate-400">Reference architectures for restricted environments, including local-model fallbacks for classified or export-controlled work.</p></li>
+          <li class="panel border border-white/10 p-5"><p class="text-sm font-semibold text-white">Per-agent scopes and signed tool calls</p><p class="mt-1 text-sm text-slate-400">Every action is scoped, logged, and replayable. Reviewers approve before outputs hit production engineering systems.</p></li>
+          <li class="panel border border-white/10 p-5"><p class="text-sm font-semibold text-white">SOC 2 Type II in flight</p><p class="mt-1 text-sm text-slate-400">Controls and audit are being formalized for early-2027 readiness. Available to design partners under MNDA today.</p></li>
+        </ul>
       </div>
     </section>
 
     <section class="border-y border-white/10 bg-white/[.025]">
-      <div class="mx-auto max-w-7xl px-5 py-16">
-        <p class="max-w-4xl text-2xl font-medium leading-10 text-white">Engineering tools were built for human operators. Agentic AI needs a platform layer that can operate those tools, preserve reviewability, and respect the infrastructure boundaries serious teams live inside.</p>
-        <a href="/manifesto.html" class="mt-6 inline-flex text-sm font-semibold text-accent hover:text-white">Read the manifesto</a>
+      <div class="mx-auto max-w-7xl px-5 py-20">
+        <p class="max-w-4xl text-2xl font-medium leading-10 text-white md:text-3xl">Engineering tools were built for human operators. Agentic AI needs a platform layer that can operate those tools, preserve reviewability, and respect the infrastructure boundaries serious teams live inside.</p>
+        <a href="/manifesto.html" class="mt-6 inline-flex text-sm font-semibold text-accent hover:text-white">Read the manifesto &rarr;</a>
       </div>
     </section>
 
-    <section id="early-access" class="mx-auto grid max-w-7xl gap-10 px-5 py-20 lg:grid-cols-[1fr_28rem]">
-      <div>
-        <p class="text-sm font-medium uppercase tracking-[.2em] text-accent">Early access</p>
-        <h2 class="mt-4 text-3xl font-semibold tracking-tight text-white md:text-4xl">Design partners before public launch.</h2>
-        <p class="mt-5 max-w-2xl leading-8 text-slate-300">We are opening a small number of design-partner conversations with engineering teams that need agentic work to stay inside their boundary.</p>
+    <section class="mx-auto max-w-7xl px-5 py-24">
+      <div class="max-w-3xl">
+        <p class="text-sm font-medium uppercase tracking-[.2em] text-accent">From the founder</p>
+        <h2 class="mt-4 text-3xl font-semibold tracking-tight text-white md:text-4xl">Built by an engineer who has shipped this category before.</h2>
+        <div class="mt-8 space-y-5 leading-8 text-slate-300">
+          <p>I have spent my career in aerospace controls and flight dynamics. I built commercial engineering tooling that real teams used to design and validate aircraft, and I watched how slow, careful, and high-stakes that work actually is. Agentic AI is the first thing I have seen that meaningfully changes the unit of engineering output.</p>
+          <p>ControlStackAI is not a chat product retrofitted for engineers. It is the platform I wish I had when I was shipping control law updates against a flight test schedule &mdash; an agent layer that respects review, integrates with the tools we already trust, and runs inside the boundary our customers require.</p>
+        </div>
+        <p class="mt-8 text-sm font-medium text-slate-400">&mdash; Matthew Mangano, founder</p>
       </div>
-      <form class="panel border border-white/10 p-6" action="/api/early-access" method="post">
-        <label class="block text-sm font-medium text-slate-200" for="email">Work email</label>
-        <input id="email" name="email" type="email" autocomplete="email" required class="mt-2 w-full rounded-md border border-white/10 bg-black/30 px-3 py-3 text-white outline-none ring-accent/40 focus:ring-2">
-        <label class="mt-5 block text-sm font-medium text-slate-200" for="company">Company</label>
-        <input id="company" name="company" type="text" autocomplete="organization" required class="mt-2 w-full rounded-md border border-white/10 bg-black/30 px-3 py-3 text-white outline-none ring-accent/40 focus:ring-2">
-        <label class="mt-5 block text-sm font-medium text-slate-200" for="role">Role</label>
-        <input id="role" name="role" type="text" autocomplete="organization-title" required class="mt-2 w-full rounded-md border border-white/10 bg-black/30 px-3 py-3 text-white outline-none ring-accent/40 focus:ring-2">
-        <button type="submit" class="mt-6 w-full rounded-md bg-accent px-4 py-3 text-sm font-semibold text-white hover:bg-accent/90">Get on the list.</button>
-      </form>
+    </section>
+
+    <section id="early-access" class="border-y border-white/10 bg-white/[.025]">
+      <div class="mx-auto grid max-w-7xl gap-10 px-5 py-24 lg:grid-cols-[1fr_28rem]">
+        <div>
+          <p class="text-sm font-medium uppercase tracking-[.2em] text-accent">Early access</p>
+          <h2 class="mt-4 text-3xl font-semibold tracking-tight text-white md:text-4xl">Design partners before public launch.</h2>
+          <p class="mt-5 max-w-2xl leading-8 text-slate-300">We are opening a small number of design-partner conversations with engineering teams that need agentic work to stay inside their boundary. Expect a real conversation, an MNDA, and a scoped pilot &mdash; not a waitlist marketing email.</p>
+          <ul class="mt-8 space-y-3 text-sm text-slate-300">
+            <li>&bull; Controls, avionics, propulsion, and simulation teams</li>
+            <li>&bull; Industrial automation and robotics groups with regulated workflows</li>
+            <li>&bull; Engineering organizations with on-prem or VPC requirements</li>
+          </ul>
+        </div>
+        <form class="panel border border-white/10 p-6" action="/api/early-access" method="post">
+          <label class="block text-sm font-medium text-slate-200" for="email">Work email</label>
+          <input id="email" name="email" type="email" autocomplete="email" required class="mt-2 w-full rounded-md border border-white/10 bg-black/30 px-3 py-3 text-white outline-none ring-accent/40 focus:ring-2">
+          <label class="mt-5 block text-sm font-medium text-slate-200" for="company">Company</label>
+          <input id="company" name="company" type="text" autocomplete="organization" required class="mt-2 w-full rounded-md border border-white/10 bg-black/30 px-3 py-3 text-white outline-none ring-accent/40 focus:ring-2">
+          <label class="mt-5 block text-sm font-medium text-slate-200" for="role">Role</label>
+          <input id="role" name="role" type="text" autocomplete="organization-title" required class="mt-2 w-full rounded-md border border-white/10 bg-black/30 px-3 py-3 text-white outline-none ring-accent/40 focus:ring-2">
+          <label class="mt-5 block text-sm font-medium text-slate-200" for="context">What are you trying to automate?</label>
+          <textarea id="context" name="context" rows="3" class="mt-2 w-full rounded-md border border-white/10 bg-black/30 px-3 py-3 text-white outline-none ring-accent/40 focus:ring-2"></textarea>
+          <button type="submit" class="mt-6 w-full rounded-md bg-accent px-4 py-3 text-sm font-semibold text-white hover:bg-accent/90">Request early access</button>
+          <p class="mt-3 text-xs text-slate-500">No marketing list. We reply individually.</p>
+        </form>
+      </div>
     </section>
   </main>
 
   <footer class="border-t border-white/10">
     <div class="mx-auto flex max-w-7xl flex-col gap-4 px-5 py-8 text-sm text-slate-400 md:flex-row md:items-center md:justify-between">
-      <p>&copy; 2026 ControlStackAI LLC · Wyoming · <a class="hover:text-white" href="mailto:hello@controlstackai.com">hello@controlstackai.com</a></p>
+      <p>&copy; 2026 ControlStackAI LLC &middot; Wyoming &middot; <a class="hover:text-white" href="mailto:hello@controlstackai.com">hello@controlstackai.com</a></p>
       <div class="flex gap-4">
+        <a href="/about.html" class="hover:text-white">About</a>
+        <a href="/manifesto.html" class="hover:text-white">Manifesto</a>
+        <a href="/contact.html" class="hover:text-white">Contact</a>
         <a href="/privacy.html" class="hover:text-white">Privacy</a>
         <a href="/terms.html" class="hover:text-white">Terms</a>
       </div>

--- a/manifesto.html
+++ b/manifesto.html
@@ -4,46 +4,75 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Manifesto - ControlStackAI</title>
-  <meta name="description" content="A working outline for the ControlStackAI engineering-agent manifesto.">
+  <meta name="description" content="Why ControlStackAI exists: an agent platform for engineering teams that cannot treat AI as shadow IT.">
   <link rel="canonical" href="https://controlstackai.com/manifesto.html">
   <link rel="icon" href="/assets/icon-neural-grid.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="/styles/tailwind-cdn.js"></script>
-  <style>body{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.panel{background:rgba(255,255,255,.035)}</style>
+  <style>body{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.panel{background:rgba(255,255,255,.035)}.prose p{margin-top:1.25rem}</style>
 </head>
 <body class="bg-ink text-white antialiased">
   <header class="sticky top-0 z-50 border-b border-white/10 bg-ink/90 backdrop-blur">
     <nav class="mx-auto flex max-w-7xl items-center justify-between px-5 py-4">
       <a href="/" class="flex items-center gap-3"><img src="/assets/icon-neural-grid.svg" class="h-8 w-8 rounded-sm" alt=""><span class="text-sm font-semibold">ControlStackAI</span></a>
-      <div class="flex items-center gap-5 text-sm text-slate-300"><a href="/manifesto.html" class="hover:text-white">Manifesto</a><a href="/#early-access" class="rounded-md bg-accent px-3 py-2 font-medium text-white hover:bg-accent/90">Early access</a></div>
+      <div class="flex items-center gap-5 text-sm text-slate-300"><a href="/about.html" class="hover:text-white">About</a><a href="/#early-access" class="rounded-md bg-accent px-3 py-2 font-medium text-white hover:bg-accent/90">Early access</a></div>
     </nav>
   </header>
+
   <main class="mx-auto max-w-3xl px-5 py-20">
     <p class="text-sm font-medium uppercase tracking-[.2em] text-accent">Manifesto</p>
     <h1 class="mt-4 text-4xl font-semibold tracking-tight md:text-6xl">The agent platform for engineers.</h1>
-    <div class="panel mt-10 border border-white/10 p-6">
-      <p class="text-slate-300">This page is intentionally a skeleton for HERALD to draft in Matt's voice before launch. The argument should be sharp, specific, and grounded in real engineering work.</p>
-    </div>
-    <!-- HERALD: draft this -->
-    <section class="mt-12 space-y-10">
+    <p class="mt-6 text-lg leading-8 text-slate-300">Engineering work is the highest-leverage thing AI can touch. It is also the place where today&rsquo;s AI tools are weakest. This is what we are building, and why.</p>
+
+    <section class="prose mt-14 space-y-10 leading-8 text-slate-300">
       <div>
-        <h2 class="text-2xl font-semibold">Engineering tools have not caught up to agentic AI</h2>
-        <p class="mt-4 leading-8 text-slate-400">Placeholder for the gap between chat interfaces and tool-operating agents.</p>
+        <h2 class="text-2xl font-semibold text-white">1. Engineering tools were built for human operators.</h2>
+        <p>MATLAB, Simulink, Stateflow, DOORS, Polarion, CATIA &mdash; every serious engineering tool assumes a human in the loop. A licensed seat. A mouse. A reviewer. That is fine for humans. It is a problem for agents.</p>
+        <p>Agentic AI needs more than a chat window. It needs a runtime that can hold open a Simulink session for six hours, push a controller redesign through the same regression suite the human team uses, and produce an artifact that a reviewer can sign off on. None of that lives in a chat interface.</p>
       </div>
+
       <div>
-        <h2 class="text-2xl font-semibold">What an agent platform for engineers means</h2>
-        <p class="mt-4 leading-8 text-slate-400">Placeholder for runtime, integrations, review loops, artifacts, and auditability.</p>
+        <h2 class="text-2xl font-semibold text-white">2. Chat is not the unit of engineering output.</h2>
+        <p>The engineering teams we care about do not ship chat transcripts. They ship models, requirements, test reports, and signed-off design changes. An AI tool that cannot produce those artifacts in the same format your team already reviews is doing demo work, not real work.</p>
+        <p>ControlStackAI agents output artifacts. They commit to your repos, edit your models, fill in your requirements managers, and run your tests. The conversation is the seam, not the product.</p>
       </div>
+
       <div>
-        <h2 class="text-2xl font-semibold">Why regulated teams need infrastructure choices</h2>
-        <p class="mt-4 leading-8 text-slate-400">Placeholder for on-prem, VPC, air-gapped, IP boundaries, and governance.</p>
+        <h2 class="text-2xl font-semibold text-white">3. Regulated teams cannot live on shadow IT.</h2>
+        <p>ITAR. EAR. CUI. Customer NDAs. Internal IP boundaries. The engineering organizations doing the most interesting work &mdash; aerospace, defense, propulsion, industrial controls &mdash; cannot route customer designs through unmanaged consumer AI tools. That is not a tooling preference. It is a contractual and legal reality.</p>
+        <p>The honest answer for these teams is not &ldquo;use AI carefully.&rdquo; It is a platform whose deployment model, audit story, and data boundary are designed for the constraints they actually live inside. On-prem. VPC. Air-gapped when it has to be. Customer-controlled inference. Per-agent scopes. Signed actions.</p>
       </div>
+
       <div>
-        <h2 class="text-2xl font-semibold">What we believe</h2>
-        <p class="mt-4 leading-8 text-slate-400">Placeholder for principles: operate existing tools, preserve human review, make costs visible, keep data boundaries real.</p>
+        <h2 class="text-2xl font-semibold text-white">4. The leverage is in the toolchain, not the chatbot.</h2>
+        <p>An agent that can search the web is interesting. An agent that can open your Simulink model, run a parameter sweep, generate a controller variant, regenerate the test report, and open a pull request against your firmware repo &mdash; that is engineering leverage. That is what changes how a team operates.</p>
+        <p>ControlStackAI is built around tool integration first. The model layer is replaceable. The toolchain integration, the engineering context, the reviewable artifacts, and the deployment boundary are the durable parts.</p>
+      </div>
+
+      <div>
+        <h2 class="text-2xl font-semibold text-white">5. Inference will keep getting cheaper. Trust will not.</h2>
+        <p>Frontier model prices fall every quarter. The cost of getting an engineering team to trust an agent with their codebase, their models, their requirements, and their schedule does not. The hard part is reviewability, scope discipline, and audit &mdash; not generating more tokens.</p>
+        <p>ControlStackAI bets that the platform layer &mdash; the one that handles trust, governance, and tool operation &mdash; is where the durable value lives.</p>
+      </div>
+
+      <div>
+        <h2 class="text-2xl font-semibold text-white">What we believe</h2>
+        <ul class="mt-4 list-disc space-y-3 pl-6 text-slate-300">
+          <li>Agents should operate the tools engineers already use, not replace them.</li>
+          <li>Every action an agent takes should be scoped, logged, and reviewable.</li>
+          <li>The deployment boundary is the customer&rsquo;s choice, not ours.</li>
+          <li>Costs and decisions should be visible, not hidden behind a chat bubble.</li>
+          <li>Engineering teams deserve a platform built by people who have actually shipped engineering work.</li>
+        </ul>
       </div>
     </section>
+
+    <div class="mt-16 panel border border-white/10 p-6">
+      <p class="text-sm text-slate-400">If this is the platform you have been looking for, we are opening a small number of design-partner conversations.</p>
+      <a href="/#early-access" class="mt-4 inline-flex rounded-md bg-accent px-4 py-2 text-sm font-semibold text-white hover:bg-accent/90">Request early access</a>
+    </div>
   </main>
-  <footer class="border-t border-white/10"><div class="mx-auto flex max-w-7xl flex-col gap-4 px-5 py-8 text-sm text-slate-400 md:flex-row md:items-center md:justify-between"><p>&copy; 2026 ControlStackAI LLC · Wyoming · <a class="hover:text-white" href="mailto:hello@controlstackai.com">hello@controlstackai.com</a></p><div class="flex gap-4"><a href="/privacy.html" class="hover:text-white">Privacy</a><a href="/terms.html" class="hover:text-white">Terms</a></div></div></footer>
+
+  <footer class="border-t border-white/10"><div class="mx-auto flex max-w-7xl flex-col gap-4 px-5 py-8 text-sm text-slate-400 md:flex-row md:items-center md:justify-between"><p>&copy; 2026 ControlStackAI LLC &middot; Wyoming &middot; <a class="hover:text-white" href="mailto:hello@controlstackai.com">hello@controlstackai.com</a></p><div class="flex gap-4"><a href="/privacy.html" class="hover:text-white">Privacy</a><a href="/terms.html" class="hover:text-white">Terms</a></div></div></footer>
 </body>
 </html>


### PR DESCRIPTION
Overnight buildout (subagent, authorized by Matt) on top of \`redesign-2026-05\`.

## Summary
- **index.html** — added Platform (4 primitives: Runtime / Context / Tools / Governance), Integrations grid (MATLAB, requirements, test, VC, compute, inference), Security & infrastructure section, founder note, expanded early-access form with context field
- **manifesto.html** — replaced HERALD placeholder with full 5-section argument in Matt's voice
- **about.html** — founder background (aerospace controls, commercial engineering tooling) without implying ACD asset reuse; explicit \"not a flight dynamics tool / token exchange / chat front-end\" positioning

## Positioning
Agent platform for regulated engineering teams. Aerospace/controls/simulation credibility. On-prem / VPC / air-gapped. No ACD-asset implication; founder framing is generic \"commercial engineering tooling\".

## Verification
- HTML parses clean (python html.parser) for all 4 pages
- Static serve on :8088 → all pages 200
- No browser available in subagent env for screenshots; visual review needed before merging to \`redesign-2026-05\` or \`main\`

## Not done
- No images regenerated, no asset changes
- No deploy — branch only, draft PR